### PR TITLE
Ack ElasticSearch 5.0 changes regarding heap size

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
@@ -296,49 +296,6 @@ public class Configuration {
                 + "\" nobody";
     }
 
-    public List<String> esArguments(ClusterState clusterState, Protos.DiscoveryInfo discoveryInfo, Protos.SlaveID slaveID) {
-        List<String> args = new ArrayList<>();
-        List<Protos.TaskInfo> taskList = clusterState.getTaskList();
-        String hostAddress = "";
-        if (taskList.size() > 0) {
-            Protos.TaskInfo taskInfo = taskList.get(0);
-            String taskId = taskInfo.getTaskId().getValue();
-            InetSocketAddress transportAddress = clusterState.getGuiTaskList().get(taskId).getTransportAddress();
-            hostAddress = NetworkUtils.addressToString(transportAddress, getIsUseIpAddress()).replace("http://", "");
-        }
-        addIfNotEmpty(args, "--default.discovery.zen.ping.unicast.hosts", hostAddress);
-        args.add("--default.http.port=" + discoveryInfo.getPorts().getPorts(Discovery.CLIENT_PORT_INDEX).getNumber());
-        args.add("--default.transport.tcp.port=" + discoveryInfo.getPorts().getPorts(Discovery.TRANSPORT_PORT_INDEX).getNumber());
-        args.add("--default.cluster.name=" + getElasticsearchClusterName());
-        args.add("--default.node.master=true");
-        args.add("--default.node.data=true");
-        args.add("--default.node.local=false");
-        args.add("--default.index.number_of_replicas=0");
-        args.add("--default.index.auto_expand_replicas=0-all");
-        if (!isFrameworkUseDocker()) {
-            String taskSpecificDataDir = taskSpecificHostDir(slaveID);
-            args.add("--path.home=" + HOST_PATH_HOME); // Cannot be overidden
-            args.add("--default.path.data=" + taskSpecificDataDir);
-            args.add("--path.conf=" + HOST_PATH_CONF); // Cannot be overidden
-        } else {
-            args.add("--path.data=" + CONTAINER_PATH_DATA); // Cannot be overidden
-        }
-        args.add("--default.bootstrap.mlockall=true");
-        args.add("--default.network.bind_host=0.0.0.0");
-        args.add("--default.network.publish_host=_non_loopback:ipv4_");
-        args.add("--default.gateway.recover_after_nodes=1");
-        args.add("--default.gateway.expected_nodes=1");
-        args.add("--default.indices.recovery.max_bytes_per_sec=100mb");
-        args.add("--default.discovery.type=zen");
-        args.add("--default.discovery.zen.fd.ping_timeout=30s");
-        args.add("--default.discovery.zen.fd.ping_interval=1s");
-        args.add("--default.discovery.zen.fd.ping_retries=30");
-        args.add("--default.discovery.zen.ping.multicast.enabled=false");
-
-
-        return args;
-    }
-
     public String taskSpecificHostDir(Protos.SlaveID slaveID) {
         return getDataDir() + "/" + getElasticsearchClusterName() + "/" + slaveID.getValue();
     }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Environment.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Environment.java
@@ -7,6 +7,10 @@ import org.apache.mesos.elasticsearch.scheduler.configuration.ExecutorEnvironmen
  */
 public class Environment {
     public String getJavaHeap() {
-        return System.getenv().get(ExecutorEnvironmentalVariables.JAVA_OPTS);
+        String javaOpts = System.getenv().get(ExecutorEnvironmentalVariables.JAVA_OPTS);
+        if (javaOpts == null || javaOpts.isEmpty()) {
+            javaOpts = System.getenv().get(ExecutorEnvironmentalVariables.ES_JAVA_OPTS);
+        }
+        return javaOpts;
     }
 }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/TaskInfoFactory.java
@@ -74,8 +74,6 @@ public class TaskInfoFactory {
 
         LOGGER.info("Creating Elasticsearch task with resources: " + resources.toString());
 
-        final List<String> args = configuration.esArguments(clusterState, discovery, offer.getSlaveId());
-
         return Protos.TaskInfo.newBuilder()
                 .setName(configuration.getTaskName())
                 .setData(toData(offer.getHostname(), hostAddress, clock.nowUTC()))
@@ -83,7 +81,7 @@ public class TaskInfoFactory {
                 .setSlaveId(offer.getSlaveId())
                 .addAllResources(resources)
                 .setDiscovery(discovery)
-                .setCommand(nativeCommand(configuration, args, elasticSearchNodeId))
+                .setCommand(nativeCommand(configuration, new List<String>(), elasticSearchNodeId))
                 .build();
     }
 
@@ -97,7 +95,6 @@ public class TaskInfoFactory {
         LOGGER.info("Creating Elasticsearch task with resources: " + resources.toString());
 
         final Protos.TaskID taskId = Protos.TaskID.newBuilder().setValue(taskId(offer, clock)).build();
-        final List<String> args = configuration.esArguments(clusterState, discovery, offer.getSlaveId());
         final Protos.ContainerInfo containerInfo = getContainer(configuration, taskId, elasticSearchNodeId, offer.getSlaveId());
 
         return Protos.TaskInfo.newBuilder()
@@ -107,7 +104,7 @@ public class TaskInfoFactory {
                 .setSlaveId(offer.getSlaveId())
                 .addAllResources(resources)
                 .setDiscovery(discovery)
-                .setCommand(dockerCommand(configuration, args, elasticSearchNodeId))
+                .setCommand(dockerCommand(configuration, new List<String>(), elasticSearchNodeId))
                 .setContainer(containerInfo)
                 .build();
     }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
@@ -68,7 +68,7 @@ public class ExecutorEnvironmentalVariables {
         if (configuration.isFrameworkUseDocker()) {
             addToList(native_mesos_library_key, native_mesos_library_path);
         }
-        addToList(ES_JAVA_OPTS, getHeapSpaceString(configuration));
+        addToList(ES_JAVA_OPTS, getHeapSpaceString(configuration, 192));
     }
 
     private void populateEnvMapForMesos(Configuration configuration, Long nodeId) {
@@ -112,5 +112,16 @@ public class ExecutorEnvironmentalVariables {
     private String getHeapSpaceString(Configuration configuration) {
         int osRam = (int) Math.min(256.0, configuration.getMem() / 4.0);
         return "" + ((int) configuration.getMem() - osRam) + "m";
+    }
+
+    /**
+     * Gets the heap space settings. Will set minimum heap space as 256, minimum or available/4, whichever is smaller. Max heap will be available space.
+     * @param configuration The mesos cluster configuration
+     * @param min The minimum heap space; used if smaller than 256 and smaller than available/4
+     * @return A string representing the java heap space.
+     */
+    private String getHeapSpaceString(Configuration configuration, int min) {
+        int osRam = (int) Math.min(256.0, min, configuration.getMem() / 4.0);
+        return "-Xms" + osRam + "m -Xmx"+ configuration.getMem() + "m";
     }
 }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
@@ -18,6 +18,7 @@ public class ExecutorEnvironmentalVariables {
     private static final String CONTAINER_PATH_SETTINGS = "/tmp/config";
     
     public static final String JAVA_OPTS = "JAVA_OPTS";
+    public static final String ES_JAVA_OPTS = "ES_JAVA_OPTS";
     public static final String ES_HEAP = "ES_HEAP_SIZE";
     public static final int EXTERNAL_VOLUME_NOT_CONFIGURED = -1;
     public static final String ELASTICSEARCH_NODE_ID = "ELASTICSEARCH_NODE_ID";
@@ -67,6 +68,7 @@ public class ExecutorEnvironmentalVariables {
         if (configuration.isFrameworkUseDocker()) {
             addToList(native_mesos_library_key, native_mesos_library_path);
         }
+        addToList(ES_JAVA_OPTS, getHeapSpaceString(configuration));
     }
 
     private void populateEnvMapForMesos(Configuration configuration, Long nodeId) {

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/configuration/ExecutorEnvironmentalVariables.java
@@ -64,11 +64,10 @@ public class ExecutorEnvironmentalVariables {
      * @param configuration
      */
     private void populateEnvMap(Configuration configuration) {
-        addToList(ES_HEAP, getHeapSpaceString(configuration));
+        addToList(ES_JAVA_OPTS, getHeapSpaceString(configuration));
         if (configuration.isFrameworkUseDocker()) {
             addToList(native_mesos_library_key, native_mesos_library_path);
         }
-        addToList(ES_JAVA_OPTS, getHeapSpaceString(configuration, 192));
     }
 
     private void populateEnvMapForMesos(Configuration configuration, Long nodeId) {
@@ -105,23 +104,13 @@ public class ExecutorEnvironmentalVariables {
     }
 
     /**
-     * Gets the heap space settings. Will set heap space to (available - 256MB) or available/4, whichever is smaller.
-     * @param configuration The mesos cluster configuration
-     * @return A string representing the java heap space.
-     */
-    private String getHeapSpaceString(Configuration configuration) {
-        int osRam = (int) Math.min(256.0, configuration.getMem() / 4.0);
-        return "" + ((int) configuration.getMem() - osRam) + "m";
-    }
-
-    /**
      * Gets the heap space settings. Will set minimum heap space as 256, minimum or available/4, whichever is smaller. Max heap will be available space.
      * @param configuration The mesos cluster configuration
      * @param min The minimum heap space; used if smaller than 256 and smaller than available/4
      * @return A string representing the java heap space.
      */
-    private String getHeapSpaceString(Configuration configuration, int min) {
-        int osRam = (int) Math.min(256.0, min, configuration.getMem() / 4.0);
-        return "-Xms" + osRam + "m -Xmx"+ configuration.getMem() + "m";
+    private String getHeapSpaceString(Configuration configuration) {
+        int osRam = (int) Math.min(256.0, configuration.getMem() / 4.0);
+        return "-Xms" + osRam + "m -Xmx" + osRam + "m";
     }
 }


### PR DESCRIPTION
The heap size in ElasticSearch 5.0 now comes from the env var
"ES_JAVA_OPTS", as opposed to the old "JAVA_OPTS". This change strives
for better compatibility with other ElasticSearch versions, and acks
ES_JAVA_OPTS as one of the options of setting the heap size.